### PR TITLE
Add config file for persisting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The purpose of pip-upgrade is to be a simple yet robust and reliable tool for up
 ## Installation
 
 	pip install pip-upgrade-tool
-	
-or	
+
+or
 
     pip install git+https://github.com/realiti4/pip-upgrade.git@master --upgrade
 
@@ -36,6 +36,10 @@ You can also exclude packages beforehand. Use `-e` or `--exclude`. The tool won'
 - `pip-upgrade --clear` Clear pip's cache.
 - `pip-upgrade --local`	By default locally installed editable packages (installed with `pip install . -e`) won't be upgraded. Use this option to upgrade everything.
 - `pip-upgrade --novenv` By default the tool won't work if virtualenv is not active. Use this if you want use it globally and pass the assertion error.
+- `pip-upgrade --reset-config` Reset config file located in `~/.pipupgrade.ini` to it's default.
+
+### Permanent Configuration
+When `pip-upgrade` is run for the first time, it will create a file in the user's home directory named `.pipupgrade.ini`. This file can be manually edited by the user for permanent configuration options. The configuration file current consists of two options under the `conf` section, `exclude` and `novenv`. `novenv` is false by default, but if set to true, the `pip-upgrade` command will not require you to be in a virtualenv, which is the same function as the `--novenv` argument. The second option, `exclude`, will take the same values as the `--exclude` argument, but these excluded packages will persist forever until removed. 
 
 #### TODO / known issues
 - Bug - Doesn't detect != cases if * is used (!=5.4.*)

--- a/pip_upgrade/main.py
+++ b/pip_upgrade/main.py
@@ -2,6 +2,8 @@ import sys
 import subprocess
 import shutil
 import argparse
+import configparser
+import os
 
 from pip_upgrade.tool import PipUpgrade
 
@@ -10,16 +12,53 @@ parser.add_argument('-e', '--exclude', nargs='+', help="Exclude packages you don
 parser.add_argument('--local', action='store_true', help="Upgrades local packages as well")
 parser.add_argument('--novenv', action='store_true', help="Disables venv check")
 parser.add_argument('--clear', action='store_true', help="Clears pip's cache")
+parser.add_argument('--reset-config', action='store_true', help='Reset config file to default')
 parser.add_argument('-q', '--query', help="Query package dependency info from pypi")
 
 args = parser.parse_args()
 
+def get_config():
+    """
+        Make config if it doesn't already exist and read it into the `config` variable. Then ensure config validity
+    """
+    home = os.path.expanduser("~")
+    config = configparser.ConfigParser()
+    if not os.path.isfile(os.path.join(home, ".pipupgrade.ini")):
+        config.add_section('conf')
+        config['conf']['exclude'] = ''
+        config['conf']['novenv'] = 'false'
+        with open(os.path.join(home, '.pipupgrade.ini'), 'w') as f:
+            config.write(f)
+    else:
+        config.read(os.path.join(home, '.pipupgrade.ini'))
 
-def check_venv():
+    # Check config validity
+    if not config.has_section('conf'):
+        print("Invalid config (no `conf` section), config will be ignored.")
+        config.add_section('conf')
+        config['conf']['novenv'] = 'false'
+        config['conf']['exclude'] = ''
+    if not config.has_option('conf', 'novenv'):
+        config['conf']['novenv'] = 'false'
+    if not config.has_option('conf', 'exclude'):
+        config['conf']['exclude'] = ''
+
+    return config
+
+def reset_config():
+    if input("Are you sure you want to completely reset the config file? (y/n): ") == 'y':
+        home = os.path.expanduser("~")
+        if os.path.isfile(os.path.join(home, '.pipupgrade.ini')):
+            os.remove(os.path.join(home, '.pipupgrade.ini'))
+    else:
+        print('Aborted, not resetting config.')
+    return get_config()
+
+def check_venv(config):
     """
         Checks if virtualenv is active, throws an asssertion error if not
     """
-    if not args.novenv:
+    if not args.novenv and config['conf']['novenv'] == 'false':
         assert not sys.prefix == sys.base_prefix, 'Please use pip-upgrade in a virtualenv. If you would like to surpass this use pip-upgrade --novenv'
 
 def clear_cache():
@@ -28,12 +67,12 @@ def clear_cache():
     """
     arg_list = [sys.executable, '-m', 'pip', 'cache', 'dir']
     output = subprocess.check_output(arg_list)
-    output = output.decode("utf-8").replace("\n", "").replace("\r", "")    
+    output = output.decode("utf-8").replace("\n", "").replace("\r", "")
 
     print(f'Folder will be deleted: {output}')
     confirm = input('Continue? (y/n): ')
-    
-    if confirm.lower() == 'y':    
+
+    if confirm.lower() == 'y':
         try:
             shutil.rmtree(output)
             print('Cache is cleared..')
@@ -43,15 +82,20 @@ def clear_cache():
         print('Aborted, if the folder was wrong, please fill an issue.')
 
 def main():
-    check_venv()
-    
+    config = get_config()
+
+    if args.reset_config:
+        config = reset_config()
+
+    check_venv(config)
+
     if args.clear:
         return clear_cache()
 
-    pip_upgrade = PipUpgrade(args)
+    pip_upgrade = PipUpgrade(args, config)
 
     be_upgraded = pip_upgrade.get_dependencies()
-    
+
     pip_upgrade.upgrade(be_upgraded)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I needed to be able to permanently ignore certain packages on my system, so I made this pull request that adds that ability. When the `pip-upgrade` command is first run, it will create a config file called `.pipupgrade.ini` in the user's home directory. This config file will allow users to permanently supply the `novenv` argument and also add permanently ignored packages. This still works with ignoring packages with `--exclude`, and `--exclude` will just add on to whatever is written in the config file. I've documented all of this in the README. I wasn't sure what type of release you would want this to be, so I didn't bump the version. If you would like me to do that, just tell me what to bump it to.